### PR TITLE
Add circular font classes

### DIFF
--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,5 +1,18 @@
 import localFont from 'next/font/local';
 
+export const circularRegular = localFont({
+  src: '../public/fonts/circular-std-2.ttf',
+  weight: '400',
+  variable: '--font-circular-regular',
+});
+
+export const circularBold = localFont({
+  src: '../public/fonts/circular-std-4.ttf',
+  weight: '700',
+  variable: '--font-circular-bold',
+});
+
+// Combined variable for convenience when applying both font weights globally
 export const circularStd = localFont({
   src: [
     {

--- a/app/globals.css
+++ b/app/globals.css
@@ -38,3 +38,13 @@ body {
   font-weight: 700;
   font-style: normal;
 }
+
+.circular-regular {
+  font-family: var(--font-circular-regular, 'CircularStd');
+  font-weight: 400;
+}
+
+.circular-bold {
+  font-family: var(--font-circular-bold, 'CircularStd');
+  font-weight: 700;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import { circularStd } from "./fonts";
+import { circularStd, circularRegular, circularBold } from "./fonts";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -16,7 +16,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${circularStd.variable} antialiased`}
+        className={`
+          ${circularStd.variable}
+          ${circularRegular.variable}
+          ${circularBold.variable}
+          antialiased`}
       >
         {children}
       </body>


### PR DESCRIPTION
## Summary
- load circular fonts individually
- expose variables for regular and bold weights
- allow using class names `circular-regular` and `circular-bold`
- include font variables on the `body`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e21dc0be88328a00be4c7ab8511a8