### PR TITLE
Implement CircularStd fonts

### DIFF
--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,28 +1,59 @@
 import localFont from 'next/font/local';
 
-export const circularRegular = localFont({
-  src: '../public/fonts/circular-std-2.ttf',
-  weight: '400',
-  variable: '--font-circular-regular',
-});
-
-export const circularBold = localFont({
-  src: '../public/fonts/circular-std-4.ttf',
-  weight: '700',
-  variable: '--font-circular-bold',
-});
-
-// Combined variable for convenience when applying both font weights globally
+// Single font family containing all weights and styles of CircularStd
 export const circularStd = localFont({
   src: [
     {
-      path: '../public/fonts/circular-std-2.ttf',
-      weight: '400',
+      path: '../public/fonts/CircularStd-Light.otf',
+      weight: '300',
+      style: 'normal',
     },
     {
-      path: '../public/fonts/circular-std-4.ttf',
+      path: '../public/fonts/CircularStd-Light Italic.otf',
+      weight: '300',
+      style: 'italic',
+    },
+    {
+      path: '../public/fonts/CircularStd-Book.otf',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: '../public/fonts/CircularStd-BookItalic.otf',
+      weight: '400',
+      style: 'italic',
+    },
+    {
+      path: '../public/fonts/CircularStd-Medium.otf',
+      weight: '500',
+      style: 'normal',
+    },
+    {
+      path: '../public/fonts/CircularStd-MediumItalic.otf',
+      weight: '500',
+      style: 'italic',
+    },
+    {
+      path: '../public/fonts/CircularStd-Bold.otf',
       weight: '700',
+      style: 'normal',
+    },
+    {
+      path: '../public/fonts/CircularStd-BoldItalic.otf',
+      weight: '700',
+      style: 'italic',
+    },
+    {
+      path: '../public/fonts/CircularStd-Black.otf',
+      weight: '900',
+      style: 'normal',
+    },
+    {
+      path: '../public/fonts/CircularStd-BlackItalic.otf',
+      weight: '900',
+      style: 'italic',
     },
   ],
   variable: '--font-circular',
+  display: 'swap',
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,26 +25,99 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+/* CircularStd font faces */
 @font-face {
   font-family: 'CircularStd';
-  src: url('/fonts/circular-std-2.ttf') format('truetype');
+  src: url('/fonts/CircularStd-Light.otf') format('opentype');
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'CircularStd';
+  src: url('/fonts/CircularStd-Light Italic.otf') format('opentype');
+  font-weight: 300;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'CircularStd';
+  src: url('/fonts/CircularStd-Book.otf') format('opentype');
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'CircularStd';
-  src: url('/fonts/circular-std-4.ttf') format('truetype');
+  src: url('/fonts/CircularStd-BookItalic.otf') format('opentype');
+  font-weight: 400;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'CircularStd';
+  src: url('/fonts/CircularStd-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'CircularStd';
+  src: url('/fonts/CircularStd-MediumItalic.otf') format('opentype');
+  font-weight: 500;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'CircularStd';
+  src: url('/fonts/CircularStd-Bold.otf') format('opentype');
   font-weight: 700;
   font-style: normal;
+}
+
+@font-face {
+  font-family: 'CircularStd';
+  src: url('/fonts/CircularStd-BoldItalic.otf') format('opentype');
+  font-weight: 700;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'CircularStd';
+  src: url('/fonts/CircularStd-Black.otf') format('opentype');
+  font-weight: 900;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'CircularStd';
+  src: url('/fonts/CircularStd-BlackItalic.otf') format('opentype');
+  font-weight: 900;
+  font-style: italic;
+}
+
+/* Utility classes for each weight */
+.circular-light {
+  font-family: var(--font-circular, 'CircularStd');
+  font-weight: 300;
 }
 
 .circular-regular {
-  font-family: var(--font-circular-regular, 'CircularStd');
+  font-family: var(--font-circular, 'CircularStd');
   font-weight: 400;
 }
 
+.circular-medium {
+  font-family: var(--font-circular, 'CircularStd');
+  font-weight: 500;
+}
+
 .circular-bold {
-  font-family: var(--font-circular-bold, 'CircularStd');
+  font-family: var(--font-circular, 'CircularStd');
   font-weight: 700;
+}
+
+.circular-black {
+  font-family: var(--font-circular, 'CircularStd');
+  font-weight: 900;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import { circularStd, circularRegular, circularBold } from "./fonts";
+import { circularStd } from "./fonts";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,13 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`
-          ${circularStd.variable}
-          ${circularRegular.variable}
-          ${circularBold.variable}
-          antialiased`}
-      >
+      <body className={`${circularStd.variable} antialiased`}>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- load CircularStd OTF fonts with `next/font`
- update layout to use the new font variable
- define all font faces and utility classes in global CSS

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e36df623083289a557373a8fb868c